### PR TITLE
Login through CLI

### DIFF
--- a/api/payloads/responses.go
+++ b/api/payloads/responses.go
@@ -5,3 +5,8 @@ type HealthcheckResponse struct {
 	Version    string `json:"version"`
 	DeployTime string `json:"deployed_at"`
 }
+
+// LoginResponse contains the response to a login request
+type LoginResponse struct {
+	Token string `json:"token"`
+}

--- a/api/service/auth.go
+++ b/api/service/auth.go
@@ -72,6 +72,6 @@ func (s *Service) loginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// return success
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("successful login of %s", loginPl.Email)))
+	w.Write([]byte(fmt.Sprintf("{\"token\":\"%s\"}", "MOCK_TOKEN")))
 	return
 }

--- a/cli/commands/account.go
+++ b/cli/commands/account.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/adrianosela/padl/cli/config"
 	"github.com/adrianosela/padl/lib/keys"
 	"golang.org/x/crypto/ssh/terminal"
 	cli "gopkg.in/urfave/cli.v1"
@@ -27,6 +28,16 @@ var AccountCmds = cli.Command{
 				passwordFlag,
 			},
 			Action: registerAccountHandler,
+		},
+		{
+			Name:  "login",
+			Usage: "login to an account on a padl server",
+			Flags: []cli.Flag{
+				emailFlag,
+				passwordFlag,
+				pathFlag,
+			},
+			Action: loginAccountHandler,
 		},
 	},
 }
@@ -77,5 +88,53 @@ func registerAccountHandler(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("registered user %s successfully!\n", email)
+	return nil
+}
+
+func loginAccountHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	path := ctx.String(name(pathFlag))
+
+	email := ctx.String(name(emailFlag))
+	if email == "" {
+		fmt.Println("Enter your email:")
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return err
+		}
+		email = strings.TrimSpace(line)
+	}
+
+	pass := ctx.String(name(passwordFlag))
+	if pass == "" {
+		fmt.Println("Enter your password:")
+		password, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		pass = strings.TrimSpace(string(password))
+	}
+
+	tk, err := c.Login(email, pass)
+	if err != nil {
+		return err
+	}
+
+	conf, err := config.GetConfig(path)
+	if err != nil {
+		return fmt.Errorf("could not get config from file system: %s", err)
+	}
+
+	conf.User = email
+	conf.Token = tk
+	if err = config.SetConfig(conf, path); err != nil {
+		return fmt.Errorf("could not write config to file system: %s", err)
+	}
+
+	fmt.Printf("user %s logged in successfully!\n", email)
 	return nil
 }

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -41,10 +41,9 @@ func configSetValidator(ctx *cli.Context) error {
 }
 
 func configSetHandler(ctx *cli.Context) error {
-	if err := config.SetConfig(
-		ctx.String(name(urlFlag)),
-		ctx.String(name(pathFlag)),
-	); err != nil {
+	if err := config.SetConfig(&config.Config{
+		HostURL: ctx.String(name(urlFlag)),
+	}, ctx.String(name(pathFlag))); err != nil {
 		return fmt.Errorf("could not set configuration: %s", err)
 	}
 	return nil
@@ -58,6 +57,13 @@ func configShowHandler(ctx *cli.Context) error {
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.Append([]string{"HOST_URL", c.HostURL})
+	if c.User != "" {
+
+		table.Append([]string{"USER", c.User})
+	}
+	if c.Token != "" {
+		table.Append([]string{"AUTH_TOKEN", c.Token})
+	}
 	table.Render()
 	return nil
 }

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -30,7 +30,7 @@ var (
 		Usage: "user email for authentication",
 	}
 	passwordFlag = cli.StringFlag{
-		Name:  "password, p",
+		Name:  "password",
 		Usage: "user password for authentication",
 	}
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -14,7 +14,8 @@ const defaultConfigFilename = ".padl"
 // Config is the padl cli configuration
 type Config struct {
 	HostURL string `json:"host_url"`
-	// AuthTK  string `json:"auth_token"`
+	User    string `json:"user, omitempty"`
+	Token   string `json:"auth_token, omitempty"`
 }
 
 // GetDefaultPath returns the best place to save / look-for a config file.
@@ -30,13 +31,13 @@ func GetDefaultPath() string {
 }
 
 // SetConfig writes a configuration file to the given path
-func SetConfig(url, path string) error {
-	if url == "" {
+func SetConfig(c *Config, path string) error {
+	if c == nil {
+		return errors.New("config cannot be nil")
+	}
+	if c.HostURL == "" {
 		return errors.New("url cannot be empty")
 	}
-	// if tk == "" {
-	// 	return errors.New("token cannot be empty")
-	// }
 	if path == "" {
 		path = GetDefaultPath()
 	}
@@ -44,7 +45,7 @@ func SetConfig(url, path string) error {
 	if err != nil {
 		return fmt.Errorf("could not create new file %s: %s", path, err)
 	}
-	byt, err := json.Marshal(&Config{HostURL: url})
+	byt, err := json.Marshal(c)
 	if err != nil {
 		return fmt.Errorf("could not marshal configuration file: %s", err)
 	}


### PR DESCRIPTION
### This PR: 
- User Get operation in DB
- Login http handler
- Login client function
- Login CLI command

### Testing

Set config:

```
10:32 $ padl config set --url http://localhost:8080
```

See config:
```
10:32 $ padl config show
+----------+-----------------------+
| HOST_URL | http://localhost:8080 |
+----------+-----------------------+
```

Register:
```
10:32 $ padl account register
Enter your email:
adriano.selaviles@gmail.com
Enter your password:
registered user adriano.selaviles@gmail.com successfully!
```
Login:
```
10:33 $ padl account login
Enter your email:
adriano.selaviles@gmail.com
Enter your password:
user adriano.selaviles@gmail.com logged in successfully!
```

See config again:
```
10:33 $ padl config show
+------------+-----------------------------+
| HOST_URL   | http://localhost:8080       |
| USER       | adriano.selaviles@gmail.com |
| AUTH_TOKEN | MOCK_TOKEN                  |
+------------+-----------------------------+
```

