### PR TITLE
Registration Flow Complete: file system key manager

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -48,7 +48,7 @@ func SetConfig(c *Config, path string) error {
 			return fmt.Errorf("could not create new directory %s: %s", path, err)
 		}
 	}
-	f, err := os.Create(fmt.Sprintf("%s/config", path))
+	f, err := os.Create(fmt.Sprintf("%s/config.json", path))
 	if err != nil {
 		return fmt.Errorf("could not create new file %s/config: %s", path, err)
 	}
@@ -71,7 +71,7 @@ func GetConfig(path string) (*Config, error) {
 }
 
 func readFSConfig(path string) (*Config, error) {
-	dat, err := ioutil.ReadFile(fmt.Sprintf("%s/config", path))
+	dat, err := ioutil.ReadFile(fmt.Sprintf("%s/config.json", path))
 	if err != nil {
 		return nil, fmt.Errorf("could not read configuration file %s: %s", path, err)
 	}

--- a/lib/keymgr/fs.go
+++ b/lib/keymgr/fs.go
@@ -1,0 +1,42 @@
+package keymgr
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// FSManager is a File System key manager
+type FSManager struct {
+	basePath string
+}
+
+// NewFSManager is the FSManager constructor
+func NewFSManager(path string) (*FSManager, error) {
+	bPath := fmt.Sprintf("%s/keys", path)
+	if _, err := os.Stat(bPath); os.IsNotExist(err) {
+		if err := os.Mkdir(bPath, 755); err != nil {
+			return nil, fmt.Errorf("could not create new directory %s: %s", path, err)
+		}
+	}
+	return &FSManager{
+		basePath: bPath,
+	}, nil
+}
+
+// PutKey saves a key by id
+func (m *FSManager) PutKey(id string, blob string) error {
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/%s", m.basePath, id), []byte(blob), 0644); err != nil {
+		return fmt.Errorf("could not write key to file system: %s", err)
+	}
+	return nil
+}
+
+// GetKey gets a key by id
+func (m *FSManager) GetKey(id string) (string, error) {
+	dat, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", m.basePath, id))
+	if err != nil {
+		return "", fmt.Errorf("could not read key from file system: %s", err)
+	}
+	return string(dat), nil
+}

--- a/lib/keymgr/manager.go
+++ b/lib/keymgr/manager.go
@@ -1,0 +1,7 @@
+package keymgr
+
+// Manager represents key management operations
+type Manager interface {
+	PutKey(string, string) error
+	GetKey(string) error
+}


### PR DESCRIPTION
We now store user's private key on registration. We should be password encrypting the private key as well. and enforcing password complexity of some kind. but we can do this later.

```
$ padl account register --email adriano.selaviles@gmail.com --password somepassword
registered user adriano.selaviles@gmail.com successfully!
```

```
$ sudo tree ~/.padl
/Users/Adriano/.padl
├── config.json
└── keys
    └── 9d8f3b8f3c39865897e933c63e5c1b7d.priv

1 directory, 2 files
```