### PR TITLE
Token Middleware

### DIFF
--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -71,7 +71,7 @@ func (a *Authenticator) ValidateJWT(tkString string) (*CustomClaims, error) {
 	var cc CustomClaims
 	//parse onto a jwt token object
 	keyfunc := func(tk *jwt.Token) (interface{}, error) {
-		return a.signer, nil // we use a single key for now
+		return &a.signer.PublicKey, nil // we use a single key for now
 	}
 	token, err := jwt.ParseWithClaims(tkString, &cc, keyfunc)
 	if err != nil {

--- a/api/service/auth.go
+++ b/api/service/auth.go
@@ -12,6 +12,7 @@ import (
 func (s *Service) addAuthEndpoints() {
 	s.Router.Methods(http.MethodPost).Path("/register").HandlerFunc(s.registrationHandler)
 	s.Router.Methods(http.MethodPost).Path("/login").HandlerFunc(s.loginHandler)
+	s.Router.Methods(http.MethodGet).Path("/valid").Handler(s.Auth(s.validHandler))
 }
 
 func (s *Service) registrationHandler(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +82,19 @@ func (s *Service) loginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// return success
+	w.WriteHeader(http.StatusOK)
+	w.Write(byt)
+	return
+}
+
+func (s Service) validHandler(w http.ResponseWriter, r *http.Request) {
+	claims := GetClaims(r)
+	byt, err := json.Marshal(&claims)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("could not marshal claims"))
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Write(byt)
 	return

--- a/api/service/middleware.go
+++ b/api/service/middleware.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/adrianosela/padl/api/auth"
+)
+
+// we need a type for context key
+type ctxKey string
+
+var (
+	// AccessTokenClaimsKey is the key in the request
+	// context object for access token claims
+	AccessTokenClaimsKey = ctxKey("access-claims")
+)
+
+// Auth wraps an HTTP handler function
+// and populates the access token claims object in the req ctx
+func (s *Service) Auth(h http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// get token from request header
+		authorization := r.Header.Get("Authorization")
+		tkStr := strings.TrimPrefix(authorization, "Bearer ")
+		if authorization == tkStr {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, "no access token in header")
+			return
+		}
+		// validate token
+		verifiedClaims, err := s.Authenticator.ValidateJWT(tkStr)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, "invalid access token")
+			return
+		}
+
+		// run handler with token in context
+		h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), AccessTokenClaimsKey, verifiedClaims)))
+	})
+}
+
+// GetClaims returns the claims in a context object
+func GetClaims(r *http.Request) *auth.CustomClaims {
+	return r.Context().Value(AccessTokenClaimsKey).(*auth.CustomClaims)
+}

--- a/cli/commands/account.go
+++ b/cli/commands/account.go
@@ -68,7 +68,7 @@ func registerAccountHandler(ctx *cli.Context) error {
 		pass = strings.TrimSpace(string(password))
 	}
 
-	priv, pub, err := keys.GenerateRSAKeyPair(2048)
+	priv, pub, err := keys.GenerateRSAKeyPair(4096)
 	if err != nil {
 		return fmt.Errorf("could not generate key pair: %s", err)
 	}


### PR DESCRIPTION
Made a jwt middleware. see the new `/valid` endpoint for usage. That claims object looks like the return below:

```
15:16 $ http http://localhost:8080/valid "Authorization: Bearer eyJhbGciOiJSUzUxMiIsImtpZCI6IjlkOjhmOjNiOjhmOjNjOjM5Ojg2OjU4Ojk3OmU5OjMzOmM2OjNlOjVjOjFiOjdkIiwidHlwIjoiSldUIn0.eyJhdWQiOiJhcGkiLCJleHAiOjE1NzM1NTYzNTIsImp0aSI6IjU0ZmVlZjMzLThkOTUtNGNlZS1hMzdmLTkyMmM2ZjBmYWJjZiIsImlhdCI6MTU3MzUxMzE1MiwiaXNzIjoiYXBpLnBhZGwuY29tIiwic3ViIjoiYWRyaWFuby5zZWxhdmlsZXNAZ21haWwuY29tIiwicHJvamVjdHMiOlsicGFkbCJdfQ.YcznXI2oXuKSrcpivFt8BlZoXOqNVtPNAVrNgOE1s83S9c8FatYEDLdo095wLPU-6K_9pKJXvbJDLmo1tQoV8_t1Z-DFteNjxIj82xhdVpnSelnCrby7IraHhTi2JGhY4ZOzHsGAQY_q-WWbFBaXx4ccQUFIVQYrJx-QBpCkOKzVC9N7b3Gvqovzw0JemwEM-g55OWf4K31k1U4Qq6H-bTQ8eMl90rReVj5LZBI7NYV80h2Mw_W54A108RuJXS4Q_roj0cZMQYXzd3ffRozLd7IQUzzpiuF2QZr7-mqy2GFEWzJF5In55OarYEXWHS6COWxb2Zk0raZaM-aDkmRqRQ"
HTTP/1.1 200 OK
Content-Length: 169
Content-Type: text/plain; charset=utf-8
Date: Mon, 11 Nov 2019 23:16:10 GMT

{
    "aud": "api",
    "exp": 1573556352,
    "iat": 1573513152,
    "iss": "api.padl.com",
    "jti": "54feef33-8d95-4cee-a37f-922c6f0fabcf",
    "projects": [
        "padl"
    ],
    "sub": "adriano.selaviles@gmail.com"
}
```