### PR TITLE
Deploy api in Google App Engine

### DIFF
--- a/api/.gcloudignore
+++ b/api/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/api/Makefile
+++ b/api/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -rf pkg bin
 
 deploy: decrypt-conf-prod
-	echo "NOT IMPLEMENTED"
+	gcloud app deploy
 
 up: dockerbuild down
 	docker run -d --name $(NAME)_service -p 8080:80 $(NAME)

--- a/api/app.yaml
+++ b/api/app.yaml
@@ -1,0 +1,7 @@
+runtime: go113
+
+handlers:
+  - url: /.*
+    secure: always
+    redirect_http_response_code: 301
+    script: auto

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -31,6 +33,13 @@ type Config struct {
 // BuildConfig returns a populated config struct from a yaml file
 func BuildConfig(filePath, version string) *Config {
 	config := configFromYaml(filePath)
+
+	// When running on Google App Engine, the PORT env
+	// variable is set by the runtime. If set, we will
+	// serve on the port specified there.
+	if port := os.Getenv("PORT"); port != "" {
+		config.Port = fmt.Sprintf(":%s", port)
+	}
 
 	config.DeployTime = time.Now()
 	config.Version = version


### PR DESCRIPTION
```
20:57 $ http https://padl-258903.appspot.com/healthcheck
HTTP/1.1 200 OK
Alt-Svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000
Cache-Control: private
Content-Encoding: gzip
Content-Type: text/plain; charset=utf-8
Date: Wed, 13 Nov 2019 04:57:47 GMT
Server: Google Frontend
Transfer-Encoding: chunked
Vary: Accept-Encoding
X-Cloud-Trace-Context: eb0c93ac00ed30750ae4294eb1f71de0;o=1

{
    "deployed_at": "2019-11-13 04:57:46.923468227 +0000 UTC m=+0.172363326",
    "version": ""
}

```