### PR TITLE
Account Show CLI Command

### DIFF
--- a/cli/commands/common.go
+++ b/cli/commands/common.go
@@ -11,5 +11,5 @@ func getClient(ctx *cli.Context) (*client.Padl, error) {
 	if err != nil {
 		return nil, err
 	}
-	return client.NewPadlClient(config.HostURL, nil)
+	return client.NewPadlClient(config.HostURL, config.Token, nil)
 }


### PR DESCRIPTION
The account show allows users to inspect their verified claims (token):

Without a `--json` flag:
```
$ padl account show
+------+--------------------------------------+
|  aud |                                  api |
|  iss |                         api.padl.com |
|  sub |          adriano.selaviles@gmail.com |
|  iat |                           1573625958 |
|  exp |                           1573669158 |
|  jti | 2474c2bc-17f3-45c9-85e9-e38796655f57 |
| proj |                                 padl |
+------+--------------------------------------+
```

With a `--json` flag:

```
$ padl account show --json | jq -r .
{
  "aud": "api",
  "exp": 1573669158,
  "jti": "2474c2bc-17f3-45c9-85e9-e38796655f57",
  "iat": 1573625958,
  "iss": "api.padl.com",
  "sub": "adriano.selaviles@gmail.com",
  "projects": [
    "padl"
  ]
}
```