### PR TITLE
add secret ops boilerplate

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/adrianosela/padl/api/auth"
 	"github.com/adrianosela/padl/api/payloads"
+	"github.com/adrianosela/padl/api/secret"
 )
 
 // Padl represents a padl API client
@@ -142,4 +143,10 @@ func (p *Padl) Valid() (*auth.CustomClaims, error) {
 		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
 	}
 	return &cc, nil
+}
+
+// GetSecrets returns the encrypted secrets for a given project
+func (p *Padl) GetSecrets( /*FIXME*/ ) (*secret.Secret, error) {
+	// TODO
+	return &secret.Secret{}, nil
 }

--- a/api/secret/secret.go
+++ b/api/secret/secret.go
@@ -1,0 +1,14 @@
+package secret
+
+// Secret represents an object containing a set of encrypted secrets
+type Secret struct {
+	KeyID string `json:"kid"`
+	// TODO
+}
+
+// Decrypt decrypts all secrets in a Secret object with a given private key
+// and returns all of the VAR_NAME=value pairs corresponding to the secrets
+func (s *Secret) Decrypt( /*FIXME*/ ) ([]string, error) {
+	// TODO
+	return []string{"MOCK_PW=mockpassword", "MOCK_PW_2=mockpassword2"}, nil
+}


### PR DESCRIPTION
the run env command will append secrets from the project config file, onto the env and run a command with that env. Example run of the `env` command within `padl run`

(see last 2 vars)

```
17:40 $ padl run env
...
GOPATH=/Users/Adriano/go
DISPLAY=localhost:0.0
LC_TERMINAL=iTerm2
RUBY_VERSION=ruby-2.4.0
_system_name=OSX
COLORTERM=truecolor
_=/usr/local/bin/padl
MOCK_PW=mockpassword
MOCK_PW_2=mockpassword2
```