### PR TITLE
KMS service endpoint stubs

### DIFF
--- a/api/service/kms.go
+++ b/api/service/kms.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"net/http"
+)
+
+func (s *Service) addKeyEndpoints() {
+	s.Router.Methods(http.MethodPost).Path("/key").Handler(s.Auth(s.createKeyHandler))
+	s.Router.Methods(http.MethodGet).Path("/key/{kid}").Handler(s.Auth(s.getKeyHandler))
+	s.Router.Methods(http.MethodDelete).Path("/key/{kid}").Handler(s.Auth(s.deleteKeyHandler))
+
+	s.Router.Methods(http.MethodPost).Path("/key/{kid}/user").Handler(s.Auth(s.addUserToKeyHandler))
+	s.Router.Methods(http.MethodDelete).Path("/key/{kid}/user").Handler(s.Auth(s.removeUserFromKeyHandler))
+}
+
+func (s *Service) createKeyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+	return
+}
+
+func (s *Service) getKeyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+	return
+}
+
+func (s *Service) deleteKeyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+	return
+}
+
+func (s *Service) addUserToKeyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+	return
+}
+
+func (s *Service) removeUserFromKeyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+	return
+}

--- a/api/service/router.go
+++ b/api/service/router.go
@@ -48,6 +48,7 @@ func NewPadlService(c *config.Config) *Service {
 	svc.addDebugEndpoints()
 	svc.addAuthEndpoints()
 	svc.addProjectEndpoints()
+	svc.addKeyEndpoints()
 
 	return svc
 }


### PR DESCRIPTION
Users may not want to deal with GCP/AWS/Azure KMS. We still need a way of providing a shared team key to all users; which means we need to be a KMS ourselves.

Note that server managed private keys does not imply that the server has access to unencrypted secrets -- all secrets are encrypted using `shamir.Split(sharedPub, userAPub, userBPub...)`

We will require 2 parts to be able to reconstruct the secret i.e. `shamir.Combine(sharedPriv, yourPriv)`, this means that because the server does not have access to the client-generated user private keys, it is unable to see the secrets.