### PR TITLE
Padl Key object

### DIFF
--- a/api/kms/key.go
+++ b/api/kms/key.go
@@ -1,0 +1,49 @@
+package kms
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	"github.com/adrianosela/padl/api/project"
+	"github.com/adrianosela/padl/lib/keys"
+)
+
+// Key represents a key managed by padl
+type Key struct {
+	ID    string         `json:"id"`
+	Name  string         `json:"name"`
+	Users map[string]int `json:"users"`
+	PEM   string         `json:"pem"`
+}
+
+// NewKey is the constructor for the padl Key object
+func NewKey(key *rsa.PrivateKey, creator, name string) (*Key, error) {
+	if key == nil {
+		return nil, errors.New("key cannot be nil")
+	}
+	return &Key{
+		ID:   keys.GetFingerprint(&key.PublicKey),
+		Name: name,
+		PEM:  string(keys.EncodePrivKeyPEM(key)),
+		Users: map[string]int{
+			creator: project.PrivilegeLvlOwner,
+		},
+	}, nil
+}
+
+// Priv returns the materialized RSA private key corresponding
+// to the padl-managed Key object
+func (k *Key) Priv() (*rsa.PrivateKey, error) {
+	return keys.DecodePrivKeyPEM([]byte(k.PEM))
+}
+
+// Pub returns the materialized RSA public key corresponding
+// to the padl-managed Key object
+func (k *Key) Pub() (*rsa.PublicKey, error) {
+	priv, err := keys.DecodePrivKeyPEM([]byte(k.PEM))
+	if err != nil {
+		return &priv.PublicKey, nil
+	}
+	return nil, fmt.Errorf("could not decode key PEM: %s", err)
+}

--- a/api/store/database.go
+++ b/api/store/database.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/adrianosela/padl/api/kms"
 	"github.com/adrianosela/padl/api/project"
 	"github.com/adrianosela/padl/api/user"
 )
@@ -8,14 +9,14 @@ import (
 // Database represents all database operations
 // for the padl API
 type Database interface {
-	// PutUser stores a new user in the db
 	PutUser(*user.User) error
-	// GetUser gets a user from the db by email
 	GetUser(string) (*user.User, error)
 
-	PutProject(project *project.Project) error
+	PutProject(*project.Project) error
+	GetProject(string) (*project.Project, error)
+	UpdateProject(*project.Project) error
 
-	GetProject(projectID string) (*project.Project, error)
-
-	UpdateProject(project *project.Project) error
+	PutKey(*kms.Key) error
+	GetKey(string) (*kms.Key, error)
+	UpdateKey(*kms.Key) error
 }

--- a/api/store/mock.go
+++ b/api/store/mock.go
@@ -3,6 +3,7 @@ package store
 import (
 	"errors"
 
+	"github.com/adrianosela/padl/api/kms"
 	"github.com/adrianosela/padl/api/project"
 	"github.com/adrianosela/padl/api/user"
 )
@@ -11,6 +12,7 @@ import (
 type MockDatabase struct {
 	users    map[string]*user.User
 	projects map[string]*project.Project
+	keys     map[string]*kms.Key
 }
 
 // NewMockDatabase is the constructor for MockDatabase
@@ -49,26 +51,39 @@ func (db *MockDatabase) PutProject(p *project.Project) error {
 }
 
 func (db *MockDatabase) GetProject(projectId string) (*project.Project, error) {
-
 	if p, ok := db.projects[projectId]; ok {
 		return p, nil
-	} else {
-		return nil, errors.New("project not found")
 	}
+	return nil, errors.New("project not found")
 }
 
 func (db *MockDatabase) UpdateProject(p *project.Project) error {
-
-	oldP, ok := db.projects[p.ID]
-	if !ok {
+	if _, ok := db.projects[p.ID]; !ok {
 		return errors.New("project not found")
 	}
-
-	if oldP.ID != p.ID {
-		delete(db.projects, oldP.ID)
-	}
-
 	db.projects[p.ID] = p
+	return nil
+}
 
+func (db *MockDatabase) PutKey(k *kms.Key) error {
+	if _, ok := db.keys[k.ID]; ok {
+		return errors.New("key already in store")
+	}
+	db.keys[k.ID] = k
+	return nil
+}
+
+func (db *MockDatabase) GetKey(id string) (*kms.Key, error) {
+	if k, ok := db.keys[id]; ok {
+		return k, nil
+	}
+	return nil, errors.New("key not found")
+}
+
+func (db *MockDatabase) UpdateKey(k *kms.Key) error {
+	if _, ok := db.keys[k.ID]; !ok {
+		return errors.New("key not found")
+	}
+	db.keys[k.ID] = k
 	return nil
 }


### PR DESCRIPTION
Padl Key is a padl-managed RSA key that we will use as an alternative to having the user provide a resource id for a cloud (GCP/AWS/Azure) key