### PR TITLE
hide rsa private key on trivial operations

### DIFF
--- a/api/kms/key.go
+++ b/api/kms/key.go
@@ -75,3 +75,9 @@ func (k *Key) IsVisibleTo(required privilege.Level, email string) bool {
 	}
 	return false
 }
+
+// HideSecret simply changes the Key object such that
+// the (secret) private key is no longer visible
+func (k *Key) HideSecret() {
+	k.PEM = "RSA PRIVATE KEY HIDDEN"
+}

--- a/api/service/kms.go
+++ b/api/service/kms.go
@@ -170,6 +170,7 @@ func (s *Service) addUserToKeyHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("error attempting to modify key: %s", err)))
 		return
 	}
+	key.HideSecret()
 	// return success
 	keybyt, err := json.Marshal(&key)
 	if err != nil {
@@ -224,6 +225,7 @@ func (s *Service) removeUserFromKeyHandler(w http.ResponseWriter, r *http.Reques
 		w.Write([]byte(fmt.Sprintf("error attempting to modify key: %s", err)))
 		return
 	}
+	key.HideSecret()
 	// return success
 	keybyt, err := json.Marshal(&key)
 	if err != nil {


### PR DESCRIPTION
Sometimes its useful to return the whole key object (i.e. for managing access to it and such) without having to see the secret associated with it. 

This PR changes the behaviour of adding and removing users to a group such that the secret is not returned along the key object