### PR TITLE
separate public and private key storage

### DIFF
--- a/api/keystore/keystore.go
+++ b/api/keystore/keystore.go
@@ -22,8 +22,12 @@ var (
 // Keystore represents all the necessary operations
 // to build a key storage solution
 type Keystore interface {
-	PutKey(*kms.Key) error
-	GetKey(string) (*kms.Key, error)
-	UpdateKey(*kms.Key) error
-	DeleteKey(string) error
+	PutPrivKey(*kms.PrivateKey) error
+	GetPrivKey(string) (*kms.PrivateKey, error)
+	UpdatePrivKey(*kms.PrivateKey) error
+	DeletePrivKey(string) error
+
+	PutPubKey(*kms.PublicKey) error
+	GetPubKey(string) (*kms.PublicKey, error)
+	DeletePubKey(string) error
 }

--- a/api/keystore/mock.go
+++ b/api/keystore/mock.go
@@ -7,47 +7,75 @@ import (
 // MockKeystore is an in-memory implementation of
 // the Keystore interface
 type MockKeystore struct {
-	keys map[string]*kms.Key
+	privs map[string]*kms.PrivateKey
+	pubs  map[string]*kms.PublicKey
 }
 
 // NewMockKeystore is the constructor for MockKeystore
 func NewMockKeystore() *MockKeystore {
 	return &MockKeystore{
-		keys: make(map[string]*kms.Key),
+		privs: make(map[string]*kms.PrivateKey),
+		pubs:  make(map[string]*kms.PublicKey),
 	}
 }
 
-// PutKey adds a key to the keystore
-func (db *MockKeystore) PutKey(k *kms.Key) error {
-	if _, ok := db.keys[k.ID]; ok {
+// PutPrivKey adds a private key to the keystore
+func (db *MockKeystore) PutPrivKey(k *kms.PrivateKey) error {
+	if _, ok := db.privs[k.ID]; ok {
 		return ErrKeyExists
 	}
-	db.keys[k.ID] = k
+	db.privs[k.ID] = k
 	return nil
 }
 
-// GetKey gets a key by id from the keystore
-func (db *MockKeystore) GetKey(id string) (*kms.Key, error) {
-	if k, ok := db.keys[id]; ok {
+// GetPrivKey gets a private key by id from the keystore
+func (db *MockKeystore) GetPrivKey(id string) (*kms.PrivateKey, error) {
+	if k, ok := db.privs[id]; ok {
 		return k, nil
 	}
 	return nil, ErrKeyNotFound
 }
 
-// DeleteKey deletes a key from the keystore
-func (db *MockKeystore) DeleteKey(id string) error {
-	if _, ok := db.keys[id]; !ok {
+// DeletePrivKey deletes a private key from the keystore
+func (db *MockKeystore) DeletePrivKey(id string) error {
+	if _, ok := db.privs[id]; !ok {
 		return ErrKeyNotFound
 	}
-	delete(db.keys, id)
+	delete(db.privs, id)
 	return nil
 }
 
-// UpdateKey updates the key in the keystore
-func (db *MockKeystore) UpdateKey(k *kms.Key) error {
-	if _, ok := db.keys[k.ID]; !ok {
+// UpdatePrivKey updates a private key in the keystore
+func (db *MockKeystore) UpdatePrivKey(k *kms.PrivateKey) error {
+	if _, ok := db.privs[k.ID]; !ok {
 		return ErrKeyNotFound
 	}
-	db.keys[k.ID] = k
+	db.privs[k.ID] = k
+	return nil
+}
+
+// PutPubKey adds a public key to the keystore
+func (db *MockKeystore) PutPubKey(k *kms.PublicKey) error {
+	if _, ok := db.pubs[k.ID]; ok {
+		return ErrKeyExists
+	}
+	db.pubs[k.ID] = k
+	return nil
+}
+
+// GetPubKey gets a public key by id from the keystore
+func (db *MockKeystore) GetPubKey(id string) (*kms.PublicKey, error) {
+	if k, ok := db.pubs[id]; ok {
+		return k, nil
+	}
+	return nil, ErrKeyNotFound
+}
+
+// DeletePubKey deletes a public key by id from the keystore
+func (db *MockKeystore) DeletePubKey(id string) error {
+	if _, ok := db.pubs[id]; !ok {
+		return ErrKeyNotFound
+	}
+	delete(db.pubs, id)
 	return nil
 }

--- a/api/kms/pub.go
+++ b/api/kms/pub.go
@@ -1,0 +1,36 @@
+package kms
+
+import (
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/adrianosela/padl/lib/keys"
+)
+
+// PublicKey represents a public key managed by padl
+type PublicKey struct {
+	ID  string `json:"id"`
+	PEM string `json:"pem"`
+}
+
+// NewPublicKey is the constructor for the padl PublicKey object
+func NewPublicKey(pubPEM string) (*PublicKey, error) {
+	pub, err := keys.DecodePubKeyPEM([]byte(pubPEM))
+	if err != nil {
+		return nil, fmt.Errorf("could not decode public key PEM: %s", err)
+	}
+	return &PublicKey{
+		ID:  keys.GetFingerprint(pub),
+		PEM: pubPEM,
+	}, nil
+}
+
+// PubRSA returns the materialized RSA public key corresponding
+// to the padl-managed Key object
+func (k *PublicKey) PubRSA() (*rsa.PublicKey, error) {
+	pub, err := keys.DecodePubKeyPEM([]byte(k.PEM))
+	if err != nil {
+		return nil, fmt.Errorf("could not decode key PEM: %s", err)
+	}
+	return pub, nil
+}

--- a/api/service/auth.go
+++ b/api/service/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/adrianosela/padl/api/kms"
 	"github.com/adrianosela/padl/api/payloads"
 	"github.com/adrianosela/padl/api/user"
 )
@@ -28,6 +29,13 @@ func (s *Service) registrationHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(err.Error()))
 		return
 	}
+	// create padl pub key object
+	pub, err := kms.NewPublicKey(regPl.PubKey)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
 	// create new user object
 	usr, err := user.NewUser(regPl.Email, regPl.Password, regPl.PubKey)
 	if err != nil {
@@ -39,6 +47,12 @@ func (s *Service) registrationHandler(w http.ResponseWriter, r *http.Request) {
 	if err := s.database.PutUser(usr); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not create new user: %s", err)))
+		return
+	}
+	// sore user's pub key publically
+	if err := s.keystore.PutPubKey(pub); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(fmt.Sprintf("could not store user's public key: %s", err)))
 		return
 	}
 	// return success

--- a/api/service/kms.go
+++ b/api/service/kms.go
@@ -12,12 +12,14 @@ import (
 )
 
 func (s *Service) addKeyEndpoints() {
+	// private key operations
 	s.Router.Methods(http.MethodPost).Path("/key").Handler(s.Auth(s.createKeyHandler))
 	s.Router.Methods(http.MethodGet).Path("/key/{kid}").Handler(s.Auth(s.getKeyHandler))
 	s.Router.Methods(http.MethodDelete).Path("/key/{kid}").Handler(s.Auth(s.deleteKeyHandler))
-
 	s.Router.Methods(http.MethodPost).Path("/key/{kid}/user").Handler(s.Auth(s.addUserToKeyHandler))
 	s.Router.Methods(http.MethodDelete).Path("/key/{kid}/user").Handler(s.Auth(s.removeUserFromKeyHandler))
+	// public key operations
+	s.Router.Methods(http.MethodGet).Path("/key/public/{kid}").Handler(s.Auth(s.getPubKeyHandler))
 }
 
 func (s *Service) createKeyHandler(w http.ResponseWriter, r *http.Request) {
@@ -36,16 +38,27 @@ func (s *Service) createKeyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// create key object and save it
-	key, err := kms.NewKey(newKeyPl.Bits, claims.Subject, newKeyPl.Name, newKeyPl.Description)
+	key, err := kms.NewPrivateKey(newKeyPl.Bits, claims.Subject, newKeyPl.Name, newKeyPl.Description)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(fmt.Sprintf("could not create new key: %s", err)))
 		return
 	}
-	// save the new key
-	if err := s.keystore.PutKey(key); err != nil {
+	// save the new priv and pub keys
+	if err := s.keystore.PutPrivKey(key); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf("could not save new project: %s", err)))
+		w.Write([]byte(fmt.Sprintf("could not save new private key: %s", err)))
+		return
+	}
+	pub, err := key.Pub()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(fmt.Sprintf("could not generate public half of key: %s", err)))
+		return
+	}
+	if err = s.keystore.PutPubKey(pub); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf("could not save new public key: %s", err)))
 		return
 	}
 	// return success
@@ -70,7 +83,7 @@ func (s *Service) getKeyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// get key from store
-	key, err := s.keystore.GetKey(id)
+	key, err := s.keystore.GetPrivKey(id)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not get key: %s", err)))
@@ -94,6 +107,38 @@ func (s *Service) getKeyHandler(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+func (s *Service) getPubKeyHandler(w http.ResponseWriter, r *http.Request) {
+	// get key id from request URL
+	var id string
+	if id = mux.Vars(r)["kid"]; id == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("no key id in request URL"))
+		return
+	}
+	// get key from store, no need to check privs, pub keys are public
+	pub, err := s.keystore.GetPubKey(id)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf("could not get key: %s", err)))
+		return
+	}
+	if pub == nil {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("key not found"))
+		return
+	}
+	// return success
+	pubByt, err := json.Marshal(&pub)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(fmt.Sprintf("could marshal response: %s", err)))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(pubByt)
+	return
+}
+
 func (s *Service) deleteKeyHandler(w http.ResponseWriter, r *http.Request) {
 	claims := GetClaims(r)
 	// get key id from request URL
@@ -104,7 +149,7 @@ func (s *Service) deleteKeyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// get key from store
-	key, err := s.keystore.GetKey(id)
+	key, err := s.keystore.GetPrivKey(id)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("error attempting to get key: %s", err)))
@@ -117,7 +162,7 @@ func (s *Service) deleteKeyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// delete key from store
-	if err = s.keystore.DeleteKey(id); err != nil {
+	if err = s.keystore.DeletePrivKey(id); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("error attempting to delete key: %s", err)))
 		return
@@ -151,7 +196,7 @@ func (s *Service) addUserToKeyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// get key from store
-	key, err := s.keystore.GetKey(id)
+	key, err := s.keystore.GetPrivKey(id)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("error attempting to get key: %s", err)))
@@ -165,7 +210,7 @@ func (s *Service) addUserToKeyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// add user to key's users and save
 	key.AddUser(addUserPl.Email, privilege.Level(addUserPl.PrivilegeLvl))
-	if err = s.keystore.UpdateKey(key); err != nil {
+	if err = s.keystore.UpdatePrivKey(key); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("error attempting to modify key: %s", err)))
 		return
@@ -206,7 +251,7 @@ func (s *Service) removeUserFromKeyHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// get key from store
-	key, err := s.keystore.GetKey(id)
+	key, err := s.keystore.GetPrivKey(id)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("error attempting to get key: %s", err)))
@@ -220,7 +265,7 @@ func (s *Service) removeUserFromKeyHandler(w http.ResponseWriter, r *http.Reques
 	}
 	// rm user from key's users and save
 	key.RemoveUser(rmUserPl.Email)
-	if err = s.keystore.UpdateKey(key); err != nil {
+	if err = s.keystore.UpdatePrivKey(key); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("error attempting to modify key: %s", err)))
 		return

--- a/api/store/mock.go
+++ b/api/store/mock.go
@@ -3,7 +3,6 @@ package store
 import (
 	"errors"
 
-	"github.com/adrianosela/padl/api/kms"
 	"github.com/adrianosela/padl/api/project"
 	"github.com/adrianosela/padl/api/user"
 )
@@ -12,7 +11,6 @@ import (
 type MockDatabase struct {
 	users    map[string]*user.User
 	projects map[string]*project.Project
-	keys     map[string]*kms.Key
 }
 
 // NewMockDatabase is the constructor for MockDatabase
@@ -20,7 +18,6 @@ func NewMockDatabase() *MockDatabase {
 	mdb := &MockDatabase{
 		users:    make(map[string]*user.User),
 		projects: make(map[string]*project.Project),
-		keys:     make(map[string]*kms.Key),
 	}
 	return mdb
 }

--- a/api/user/user.go
+++ b/api/user/user.go
@@ -13,7 +13,7 @@ type User struct {
 	KeyID      string
 }
 
-// NewUser takes in user email, password, and public key
+// NewUser takes in user email, password, and public key id
 // and returns a populated User with the hashed password
 func NewUser(email, pass, keyID string) (*User, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.MinCost)

--- a/api/user/user.go
+++ b/api/user/user.go
@@ -10,12 +10,12 @@ import (
 type User struct {
 	Email      string
 	HashedPass string
-	Key        string
+	KeyID      string
 }
 
 // NewUser takes in user email, password, and public key
 // and returns a populated User with the hashed password
-func NewUser(email, pass, key string) (*User, error) {
+func NewUser(email, pass, keyID string) (*User, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.MinCost)
 	if err != nil {
 		return nil, fmt.Errorf("could not hash password: %s", err)
@@ -23,7 +23,7 @@ func NewUser(email, pass, key string) (*User, error) {
 	return &User{
 		Email:      email,
 		HashedPass: string(hash),
-		Key:        key,
+		KeyID:      keyID,
 	}, nil
 }
 


### PR DESCRIPTION
closes https://github.com/adrianosela/padl/issues/51

Allows us to fetch a user's public key:

```
13:55 $ http http://localhost:8080/key/public/${KEY_ID} "Authorization: Bearer ${TOKEN}" | jq -r .
{
  "id": "fc087b15d200b4afc85f329ebb86e219",
  "pem": "-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAykhVmiAc1hHGD9sZbugnzdNl2JW7ojYCMMymZaEZesXP+Tvlrelo\njNHgccB0oI4C9QXhZM7Ij4vWewNHjbvb/4+JLOfggaQ72YACk9hyUdfcCxqz3l8X\nLPb3aRhMg0N48St+D2mStrCDbZJeT7g/yHAZGKuxOzLN7e1kLHl8yxN0h5lRNQqa\nql4CFaeQG/KJso8BZ4KbKnfsrgKSdn99r1b7kU6CqFGN5c0wEEb4KUFJ8BEAHA8C\nyrfwqA++AKbKMlXbZb0hpQkr+OZQXKXFP+EgYQjCNtx1Ia+hhGgFQP/Llf6hUrtJ\nNYyzQrPSNcgeJwNXJRPALZWLD79Su6AiNCss2OrNaOjWWAoUirKYUMBnfRuA3jY3\ngXDA5+UquULs0HS4dhRJzI3YAOCgpuXmS4gMzmmYBJh1FM0ocfnp2s6WpW3PTNmi\n8c4GqIFWa5Qe0RGilyEhzyhPQcvvtNWnHGb26wzyF+4PeDNsG0+yWhb3YwDGE8UW\n41iZYNnDP61t6qnB1hJ8lLEIo4SKcY0k7JMGAHCxnpjWRTlcIL+R7DZxo+LNz1Ym\nGi3KgC46dbE1B+hrrj+NMcsUtaT5SJXi2vRQHRQEJAANtp4Sv3jCmlJY5LjpI5Xq\nKkZUvmYhWcjZoMwTL51+LumkbOOHpMt6HpQVQr04m0hOL5Kti1OAiL8CAwEAAQ==\n-----END RSA PUBLIC KEY-----\n"
}
```
