### PR TITLE
add and remove user to key ACL commands

### DIFF
--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -49,6 +49,10 @@ var (
 		Name:  "bits",
 		Usage: "key bit size - one of { 512, 1024, 2048, 4096 }",
 	}
+	privFlag = cli.IntFlag{
+		Name:  "privilege",
+		Usage: "privilege level to assign - { Reader: 0, Editor:1, Owner:2 }",
+	}
 
 	// option flags
 	jsonFlag = cli.BoolFlag{

--- a/cli/commands/kms.go
+++ b/cli/commands/kms.go
@@ -15,12 +15,12 @@ var KMSCmds = cli.Command{
 	Subcommands: []cli.Command{
 		{
 			Name:  "create",
-			Usage: "create a server managed private key for decryption",
+			Usage: "create a server managed key-pair",
 			Flags: []cli.Flag{
 				jsonFlag,
 				asMandatory(nameFlag),
 				asMandatory(descriptionFlag),
-				asMandatoryInt(bitsFlag),
+				withDefaultInt(bitsFlag, 2048),
 			},
 			Before: createKeyValidator,
 			Action: createKeyHandler,
@@ -45,11 +45,34 @@ var KMSCmds = cli.Command{
 			Before: publicKeyValidator,
 			Action: publicKeyHandler,
 		},
+		{
+			Name:  "add-user",
+			Usage: "add a user to a key-pair's access control list",
+			Flags: []cli.Flag{
+				jsonFlag,
+				asMandatory(idFlag),
+				asMandatory(emailFlag),
+				withDefaultInt(privFlag, 0),
+			},
+			Before: addUserToKeyValidator,
+			Action: addUserToKeyHandler,
+		},
+		{
+			Name:  "remove-user",
+			Usage: "remove a user from a key-pair's access control list",
+			Flags: []cli.Flag{
+				jsonFlag,
+				asMandatory(idFlag),
+				asMandatory(emailFlag),
+			},
+			Before: rmUserToKeyValidator,
+			Action: rmUserToKeyHandler,
+		},
 	},
 }
 
 func createKeyValidator(ctx *cli.Context) error {
-	return assertSet(ctx, nameFlag, descriptionFlag, bitsFlag)
+	return assertSet(ctx, nameFlag, descriptionFlag)
 }
 
 func privateKeyValidator(ctx *cli.Context) error {
@@ -58,6 +81,14 @@ func privateKeyValidator(ctx *cli.Context) error {
 
 func publicKeyValidator(ctx *cli.Context) error {
 	return assertSet(ctx, idFlag)
+}
+
+func addUserToKeyValidator(ctx *cli.Context) error {
+	return assertSet(ctx, idFlag, emailFlag)
+}
+
+func rmUserToKeyValidator(ctx *cli.Context) error {
+	return assertSet(ctx, idFlag, emailFlag)
 }
 
 func createKeyHandler(ctx *cli.Context) error {
@@ -133,5 +164,60 @@ func publicKeyHandler(ctx *cli.Context) error {
 	}
 
 	fmt.Println(k.PEM)
+	return nil
+}
+
+func addUserToKeyHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	id := ctx.String(name(idFlag))
+	email := ctx.String(name(emailFlag))
+	privilege := ctx.Int(name(privFlag))
+
+	k, err := c.AddUserToPrivateKey(id, email, privilege)
+	if err != nil {
+		return fmt.Errorf("could not get public key: %s", err)
+	}
+
+	if ctx.Bool(name(jsonFlag)) {
+		byt, err := json.Marshal(&k)
+		if err != nil {
+			return fmt.Errorf("could not marshal response: %s", err)
+		}
+		fmt.Println(string(byt))
+		return nil
+	}
+
+	fmt.Println(k.ID)
+	return nil
+}
+
+func rmUserToKeyHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	id := ctx.String(name(idFlag))
+	email := ctx.String(name(emailFlag))
+
+	k, err := c.RemoveUserFromPrivateKey(id, email)
+	if err != nil {
+		return fmt.Errorf("could not get public key: %s", err)
+	}
+
+	if ctx.Bool(name(jsonFlag)) {
+		byt, err := json.Marshal(&k)
+		if err != nil {
+			return fmt.Errorf("could not marshal response: %s", err)
+		}
+		fmt.Println(string(byt))
+		return nil
+	}
+
+	fmt.Println(k.ID)
 	return nil
 }


### PR DESCRIPTION
This is the third and last PR involving padl-KMS cli commands.
closes https://github.com/adrianosela/padl/issues/48

### Testing

Add a user to a key's ACL
```
15:38 $ padl kms add-user --id e9288205803099018d6f7a5b05797799 --email felipeballesteros1@gmai.com --json | jq -r .
{
  "id": "e9288205803099018d6f7a5b05797799",
  "name": "First Key",
  "description": "this is the very first key created on the cli",
  "users": {
    "adriano.selaviles@gmai.com": 2,
    "felipeballesteros1@gmai.com": 0
  },
  "pem": "RSA PRIVATE KEY HIDDEN"
}
```

Remove a user from a key's ACL
```
15:38 $ padl kms remove-user --id e9288205803099018d6f7a5b05797799 --email felipeballesteros1@gmai.com --json | jq -r .
{
  "id": "e9288205803099018d6f7a5b05797799",
  "name": "First Key",
  "description": "this is the very first key created on the cli",
  "users": {
    "adriano.selaviles@gmai.com": 2
  },
  "pem": "RSA PRIVATE KEY HIDDEN"
}
```

This is what the padl kms menu looks like, its nice:
```
15:40 $ padl kms
NAME:
   padl kms - manage private and public keys

USAGE:
   padl kms command [command options] [arguments...]

COMMANDS:
     create       create a server managed key-pair
     private      get an RSA private key for inspection/decryption
     public       get an RSA public key for inspection/encryption
     add-user     add a user to a key-pair's access control list
     remove-user  remove a user from a key-pair's access control list

OPTIONS:
   --help, -h  show help

```