### PR TITLE
Added create project command and client

### DIFF
--- a/api/client/project.go
+++ b/api/client/project.go
@@ -45,10 +45,10 @@ func (p *Padl) CreateProject(name, description string) (*padlfile.File, error) {
 		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
 	}
 
-	var r payloads.NewProjectResponse
-	if err := json.Unmarshal(respByt, &r); err != nil {
+	var pf padlfile.File
+	if err := json.Unmarshal(respByt, &pf); err != nil {
 		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
 	}
 
-	return r.Padfile, nil
+	return &pf, nil
 }

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/adrianosela/padl/api/payloads"
+	"github.com/adrianosela/padl/lib/padlfile"
+)
+
+// CreateProject creates a new project and returns a signed padlfile
+func (p *Padl) CreateProject(name, description string) (*padlfile.File, error) {
+
+	pl := &payloads.NewProjectRequest{
+		Name:        name,
+		Description: description,
+	}
+	plBytes, err := json.Marshal(&pl)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshall payload: %s", err)
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/project", p.HostURL),
+		bytes.NewBuffer(plBytes))
+	if err != nil {
+		return nil, fmt.Errorf("could not build http requests: %s", err)
+	}
+	p.setAuth(req)
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not send http request: %s", err)
+	}
+
+	respByt, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not read http response body: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
+	}
+
+	var r payloads.NewProjectResponse
+	if err := json.Unmarshal(respByt, &r); err != nil {
+		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
+	}
+
+	return r.Padfile, nil
+}

--- a/api/payloads/project.go
+++ b/api/payloads/project.go
@@ -1,6 +1,10 @@
 package payloads
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/adrianosela/padl/lib/padlfile"
+)
 
 // NewProjectRequest TODO
 type NewProjectRequest struct {
@@ -32,7 +36,7 @@ type DeleteDeployKeyRequest struct {
 
 // NewProjectResponse TODO
 type NewProjectResponse struct {
-	ID string `json:"id"`
+	Padfile *padlfile.File `json:"id"`
 }
 
 // CreateDeployKeyResponse TODO

--- a/api/payloads/project.go
+++ b/api/payloads/project.go
@@ -2,8 +2,6 @@ package payloads
 
 import (
 	"errors"
-
-	"github.com/adrianosela/padl/lib/padlfile"
 )
 
 // NewProjectRequest TODO
@@ -32,11 +30,6 @@ type CreateDeployKeyRequest struct {
 // DeleteDeployKeyRequest TODO
 type DeleteDeployKeyRequest struct {
 	DeployKeyName string `json:"deployKey"`
-}
-
-// NewProjectResponse TODO
-type NewProjectResponse struct {
-	Padfile *padlfile.File `json:"id"`
 }
 
 // CreateDeployKeyResponse TODO

--- a/api/project/project.go
+++ b/api/project/project.go
@@ -9,10 +9,11 @@ import (
 
 // Project represents a project in Padl
 type Project struct {
-	ID         string
-	Name       string
-	Members    map[string]privilege.Level
-	DeployKeys map[string]string
+	ID           string
+	Name         string
+	Members      map[string]privilege.Level
+	DeployKeys   map[string]string
+	PadlfileHash string
 }
 
 // NewProject is the project object constructor

--- a/api/service/project.go
+++ b/api/service/project.go
@@ -69,7 +69,7 @@ func (s *Service) createProjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	byt, err := json.Marshal(&payloads.NewProjectResponse{Padfile: pf})
+	byt, err := json.Marshal(&pf)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(fmt.Sprintf("could not marshal project json: %s", err)))

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -59,6 +59,10 @@ var (
 		Name:  "json, j",
 		Usage: "print raw json -- don't pretty print",
 	}
+	path = cli.StringFlag{
+		Name:  "path, p",
+		Usage: "override default .padlfile path",
+	}
 )
 
 // name returns the long name of a flag

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -59,10 +59,6 @@ var (
 		Name:  "json, j",
 		Usage: "print raw json -- don't pretty print",
 	}
-	path = cli.StringFlag{
-		Name:  "path, p",
-		Usage: "override default .padlfile path",
-	}
 )
 
 // name returns the long name of a flag

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -26,7 +26,7 @@ var ProjectCmds = cli.Command{
 			Flags: []cli.Flag{
 				asMandatory(nameFlag),
 				asMandatory(descriptionFlag),
-				pathFlag,
+				path,
 				// Defaulting to yml
 				jsonFlag,
 			},
@@ -50,7 +50,7 @@ func createProjectHandler(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not initialize client: %s", err)
 	}
-	p := ctx.String(name(pathFlag))
+	p := ctx.String(name(path))
 	pname := ctx.String(name(nameFlag))
 	descr := ctx.String(name(descriptionFlag))
 	json := ctx.Bool(name(jsonFlag))
@@ -63,12 +63,11 @@ func createProjectHandler(ctx *cli.Context) error {
 		}
 	}
 
-	if !strings.Contains(p, ".json") && !strings.Contains(p, ".yaml") {
-		return fmt.Errorf("provide file name and type")
+	if !strings.HasSuffix(p, ".json") && !strings.HasSuffix(p, ".yaml") {
+		return fmt.Errorf("invalid file extension, must be one of { \".yaml\", \".json\" }")
 	}
 
 	pf, err := c.CreateProject(pname, descr)
-
 	if err != nil {
 		return fmt.Errorf("error creating project: %s", err)
 	}

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -26,7 +26,7 @@ var ProjectCmds = cli.Command{
 			Flags: []cli.Flag{
 				asMandatory(nameFlag),
 				asMandatory(descriptionFlag),
-				path,
+				pathFlag,
 				// Defaulting to yml
 				jsonFlag,
 			},
@@ -50,20 +50,20 @@ func createProjectHandler(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not initialize client: %s", err)
 	}
-	p := ctx.String(name(path))
+	path := ctx.String(name(pathFlag))
 	pname := ctx.String(name(nameFlag))
 	descr := ctx.String(name(descriptionFlag))
 	json := ctx.Bool(name(jsonFlag))
 
-	if p == "" {
+	if path == "" {
 		if json {
-			p = "./padlfile.json"
+			path = "./padlfile.json"
 		} else {
-			p = "./padlfile.yaml"
+			path = "./padlfile.yaml"
 		}
 	}
 
-	if !strings.HasSuffix(p, ".json") && !strings.HasSuffix(p, ".yaml") {
+	if !strings.HasSuffix(path, ".json") && !strings.HasSuffix(path, ".yaml") {
 		return fmt.Errorf("invalid file extension, must be one of { \".yaml\", \".json\" }")
 	}
 
@@ -72,7 +72,7 @@ func createProjectHandler(ctx *cli.Context) error {
 		return fmt.Errorf("error creating project: %s", err)
 	}
 
-	err = pf.Write(p)
+	err = pf.Write(path)
 	if err != nil {
 		return fmt.Errorf("unable to write padl file: %s", err)
 	}

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"fmt"
+	"strings"
+
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -18,10 +21,61 @@ var ProjectCmds = cli.Command{
 			},
 			Action: projectListHandler,
 		},
+		{
+			Name: "create",
+			Flags: []cli.Flag{
+				asMandatory(nameFlag),
+				asMandatory(descriptionFlag),
+				pathFlag,
+				// Defaulting to yml
+				jsonFlag,
+			},
+			Before: createProjectValidator,
+			Action: createProjectHandler,
+		},
 	},
 }
 
 func projectListHandler(ctx *cli.Context) error {
 	// TODO
+	return nil
+}
+
+func createProjectValidator(ctx *cli.Context) error {
+	return assertSet(ctx, nameFlag, descriptionFlag)
+}
+
+func createProjectHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+	p := ctx.String(name(pathFlag))
+	pname := ctx.String(name(nameFlag))
+	descr := ctx.String(name(descriptionFlag))
+	json := ctx.Bool(name(jsonFlag))
+
+	if p == "" {
+		if json {
+			p = "./padlfile.json"
+		} else {
+			p = "./padlfile.yaml"
+		}
+	}
+
+	if !strings.Contains(p, ".json") && !strings.Contains(p, ".yaml") {
+		return fmt.Errorf("provide file name and type")
+	}
+
+	pf, err := c.CreateProject(pname, descr)
+
+	if err != nil {
+		return fmt.Errorf("error creating project: %s", err)
+	}
+
+	err = pf.Write(p)
+	if err != nil {
+		return fmt.Errorf("unable to write padl file: %s", err)
+	}
 	return nil
 }


### PR DESCRIPTION
### Added "project create" command

### Flags
- --name (required)
- --description (required)
- --path (optional)
    - default: `./.padlfile.yaml`
- --json (optional)
    - default: `json`

### Example
```
-> ./padl project create --name felipeproj --description "A project" --path "./.padlfile.json"

created project a2dbe0db-b1a1-4d2c-8206-138b0b139929 successfully!
```
- .padlfile.json
```
{
  "data": {
    "project_id": "3b4d0f05-0199-4b02-8169-632b9ca3cc5d",
    "variables": {
      "var1": "_var1_"
    },
    "keys": [
      "key1"
    ],
    "shared_key": "mockSharedKey"
  },
  "HMAC": "2750058f18b5ec7b6c4aea09d991742b76c325c85365b5dee51b078760265a2b634bdb6310625cc3e882600fd2dc5bafcd40a4987dcb5608187c5b6d56fc7bd3"
}
```
- yaml 
```
data:
  project_id: a2dbe0db-b1a1-4d2c-8206-138b0b139929
  variables:
    var1: _var1_
  keys:
  - key1
  shared_key: mockSharedKey
HMAC: f98e3c5e4ec14bcc7ab014938bf311c9e3cbc61f81e0b49ef7666d7c32195efe7a20ccca444428e70d70663d82f81b7bed67069876be622cb5768410c0d9ab64
```