### PR TITLE
Get / Create project commands

### DIFF
--- a/api/client/project.go
+++ b/api/client/project.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/adrianosela/padl/api/project"
+
 	"github.com/adrianosela/padl/api/payloads"
 	"github.com/adrianosela/padl/lib/padlfile"
 )
@@ -51,4 +53,29 @@ func (p *Padl) CreateProject(name, description string) (*padlfile.File, error) {
 	}
 
 	return &pf, nil
+}
+
+func (p *Padl) GetProject(pid string) (*project.Project, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/project/%s", p.HostURL, pid), nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not build http request: %s", err)
+	}
+	p.setAuth(req)
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not send http request: %s", err)
+	}
+	respByt, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not read http response body: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non 200 status code received: %d - %s", resp.StatusCode, string(respByt))
+	}
+	var project project.Project
+	if err := json.Unmarshal(respByt, &project); err != nil {
+		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
+	}
+	return &project, nil
 }

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -59,6 +59,10 @@ var (
 		Name:  "json, j",
 		Usage: "print raw json -- don't pretty print",
 	}
+	fmtFlag = cli.StringFlag{
+		Name:  "fmt",
+		Usage: "format of padlfile - one of { \".yaml\", \".json\" }",
+	}
 )
 
 // name returns the long name of a flag

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	cli "gopkg.in/urfave/cli.v1"
@@ -33,6 +35,14 @@ var ProjectCmds = cli.Command{
 			},
 			Before: createProjectValidator,
 			Action: createProjectHandler,
+		},
+		{
+			Name:  "get",
+			Usage: "finds an existing project user is a memeber of",
+			Flags: []cli.Flag{
+				asMandatory(idFlag),
+			},
+			Action: getProjectHandler,
 		},
 	},
 }
@@ -77,6 +87,27 @@ func createProjectHandler(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to write padl file: %s", err)
 	}
-	fmt.Printf("project %s initialized successfully!", pname)
+	fmt.Printf("project %s:%s initialized successfully!\n", pname, pf.Data.Project)
+	return nil
+}
+
+func getProjectHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	id := ctx.String(name(idFlag))
+
+	project, err := c.GetProject(id)
+	if err != nil {
+		return fmt.Errorf("error finding project: %s", err)
+	}
+
+	prettyJSON, err := json.MarshalIndent(project, "", "    ")
+	if err != nil {
+		log.Fatal("Failed to generate json", err)
+	}
+	fmt.Printf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	cli "gopkg.in/urfave/cli.v1"
@@ -107,7 +106,7 @@ func getProjectHandler(ctx *cli.Context) error {
 
 	prettyJSON, err := json.MarshalIndent(project, "", "    ")
 	if err != nil {
-		log.Fatal("Failed to generate json", err)
+		return fmt.Errorf("Failed to generate json: %s", err)
 	}
 	fmt.Printf("%s\n", string(prettyJSON))
 	return nil

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -56,6 +56,10 @@ func createProjectValidator(ctx *cli.Context) error {
 	return assertSet(ctx, nameFlag, descriptionFlag)
 }
 
+func getProjectValidator(ctx *cli.Context) error {
+	return assertSet(ctx, idFlag)
+}
+
 func createProjectHandler(ctx *cli.Context) error {
 	c, err := getClient(ctx)
 	if err != nil {
@@ -110,8 +114,4 @@ func getProjectHandler(ctx *cli.Context) error {
 	}
 	fmt.Printf("%s\n", string(prettyJSON))
 	return nil
-}
-
-func getProjectValidator(ctx *cli.Context) error {
-	return assertSet(ctx, idFlag)
 }

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -42,6 +42,7 @@ var ProjectCmds = cli.Command{
 			Flags: []cli.Flag{
 				asMandatory(idFlag),
 			},
+			Before: getProjectValidator,
 			Action: getProjectHandler,
 		},
 	},
@@ -110,4 +111,8 @@ func getProjectHandler(ctx *cli.Context) error {
 	}
 	fmt.Printf("%s\n", string(prettyJSON))
 	return nil
+}
+
+func getProjectValidator(ctx *cli.Context) error {
+	return assertSet(ctx, idFlag)
 }

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -22,13 +22,14 @@ var ProjectCmds = cli.Command{
 			Action: projectListHandler,
 		},
 		{
-			Name: "create",
+			Name:  "create",
+			Usage: "create a new project",
 			Flags: []cli.Flag{
 				asMandatory(nameFlag),
 				asMandatory(descriptionFlag),
 				pathFlag,
 				// Defaulting to yml
-				jsonFlag,
+				withDefault(fmtFlag, ".yaml"),
 			},
 			Before: createProjectValidator,
 			Action: createProjectHandler,
@@ -53,13 +54,13 @@ func createProjectHandler(ctx *cli.Context) error {
 	path := ctx.String(name(pathFlag))
 	pname := ctx.String(name(nameFlag))
 	descr := ctx.String(name(descriptionFlag))
-	json := ctx.Bool(name(jsonFlag))
+	format := ctx.String(name(fmtFlag))
 
 	if path == "" {
-		if json {
-			path = "./padlfile.json"
+		if format == ".json" {
+			path = "./.padlfile.json"
 		} else {
-			path = "./padlfile.yaml"
+			path = "./.padlfile.yaml"
 		}
 	}
 
@@ -76,5 +77,6 @@ func createProjectHandler(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to write padl file: %s", err)
 	}
+	fmt.Printf("project %s initialized successfully!", pname)
 	return nil
 }


### PR DESCRIPTION
## Create
- Added command description
- Replaced `jsonFlag` for `fmtFlag`
- Added success message upon successful project creation

## Get
Finds a project a user is member of based on project id
**TODO:** Add find by name functionality

### Flags
- id (required)

### Example
```
-> ./padl project get --id b18031e1-3081-447e-bd6f-18a6a144afe6

{
    "ID": "b18031e1-3081-447e-bd6f-18a6a144afe6",
    "Name": "felipepp22",
    "Members": {
        "felipeballesteros1@gmail.com": 2
    },
    "DeployKeys": {},
    "PadlfileHash": "828c57caf665d7a993dfbc2d3ea8a256babfd227a2b521178c2bf01da34f2c294141a6c7cae2fa96f1f935765c67711fd9ce493a256c7a5c3899e656bce4a66a"
}
```