### PR TITLE
Move project commands to subcommands

### DIFF
--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -56,55 +56,67 @@ var ProjectCmds = cli.Command{
 			Action: projectListHandler,
 		},
 		{
-			Name:  "add-secret",
-			Usage: "add a secret to a project",
-			Flags: []cli.Flag{
-				privateKeyFlag,
-				jsonFlag,
+			Name:  "secret",
+			Usage: "manage secrets for project",
+			Subcommands: []cli.Command{
+				{
+					Name:  "add",
+					Usage: "add a secret to a project",
+					Flags: []cli.Flag{
+						privateKeyFlag,
+						jsonFlag,
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectAddSecretHandler,
+				},
+				{
+					Name:  "update",
+					Usage: "update a secret in a project",
+					Flags: []cli.Flag{
+						privateKeyFlag,
+						jsonFlag,
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectUpdateSecretHandler,
+				},
+				{
+					Name:  "remove",
+					Usage: "delete a secret from a project",
+					Flags: []cli.Flag{
+						privateKeyFlag,
+						jsonFlag,
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectRemoveSecretHandler,
+				},
 			},
-			Before: checkCanModifyPadlFile,
-			Action: projectAddSecretHandler,
 		},
 		{
-			Name:  "update-secret",
-			Usage: "update a secret in a project",
-			Flags: []cli.Flag{
-				privateKeyFlag,
-				jsonFlag,
+			Name:  "user",
+			Usage: "manage users for project",
+			Subcommands: []cli.Command{
+				{
+					Name:  "add",
+					Usage: "add a user to a project",
+					Flags: []cli.Flag{
+						asMandatory(nameFlag),
+						asMandatory(emailFlag),
+						asMandatoryInt(privFlag),
+					},
+					Before: addUserValidator,
+					Action: addUserHandler,
+				},
+				{
+					Name:  "remove",
+					Usage: "remove a user from a project",
+					Flags: []cli.Flag{
+						asMandatory(nameFlag),
+						asMandatory(emailFlag),
+					},
+					Before: removeUserValidator,
+					Action: removeUserHandler,
+				},
 			},
-			Before: checkCanModifyPadlFile,
-			Action: projectUpdateSecretHandler,
-		},
-		{
-			Name:  "remove-secret",
-			Usage: "delete a secret from a project",
-			Flags: []cli.Flag{
-				privateKeyFlag,
-				jsonFlag,
-			},
-			Before: checkCanModifyPadlFile,
-			Action: projectRemoveSecretHandler,
-		},
-		{
-			Name:  "add-user",
-			Usage: "add a user to a project",
-			Flags: []cli.Flag{
-				asMandatory(nameFlag),
-				asMandatory(emailFlag),
-				asMandatoryInt(privFlag),
-			},
-			Before: addUserValidator,
-			Action: addUserHandler,
-		},
-		{
-			Name:  "remove-user",
-			Usage: "remove a user from a project",
-			Flags: []cli.Flag{
-				asMandatory(nameFlag),
-				asMandatory(emailFlag),
-			},
-			Before: removeUserValidator,
-			Action: removeUserHandler,
 		},
 	},
 }


### PR DESCRIPTION
Our `project` menu was getting quite big:

```
20:46 $ padl project
NAME:
   padl project - manage projects

USAGE:
   padl project command [command options] [arguments...]

COMMANDS:
     create         create a new padl project
     delete         delete a padl project
     get            get a padl project by name
     list           get all your padl projects
     add-secret     add a secret to a project
     update-secret  update a secret in a project
     remove-secret  delete a secret from a project
     add-user       add a user to a project
     remove-user    remove a user from a project

OPTIONS:
   --help, -h  show help

```

I moved user and secrets commands onto subcommands, now it looks like this:

```
20:44 $ padl project
NAME:
   padl project - manage projects

USAGE:
   padl project command [command options] [arguments...]

COMMANDS:
     create  create a new padl project
     delete  delete a padl project
     get     get a padl project by name
     list    get all your padl projects
     secret  manage secrets for project
     user    manage users for project

OPTIONS:
   --help, -h  show help

```

```
20:44 $ padl project user
NAME:
   padl project user - manage users for project

USAGE:
   padl project user command [command options] [arguments...]

COMMANDS:
     add     add a user to a project
     remove  remove a user from a project

OPTIONS:
   --help, -h  show help
```

```
20:45 $ padl project secret
NAME:
   padl project secret - manage secrets for project

USAGE:
   padl project secret command [command options] [arguments...]

COMMANDS:
     add     add a secret to a project
     update  update a secret in a project
     remove  delete a secret from a project

OPTIONS:
   --help, -h  show help

```