### PR TITLE
Jwt deploy keys

### DIFF
--- a/api/auth/authenticator.go
+++ b/api/auth/authenticator.go
@@ -7,8 +7,11 @@ import (
 )
 
 const (
-	defaultPadlIssuer   = "padl.adrianosela.com"
-	defaultPadlAudience = "api"
+	defaultPadlIssuer = "padl.adrianosela.com"
+	//PadlAPIAudience user audience for Padl API
+	PadlAPIAudience = "api"
+	//PadlDeployKeyAudience deployKey audience for Padl API
+	PadlDeployKeyAudience = "DeployKey"
 )
 
 // Authenticator is the module in charge of authentication
@@ -31,7 +34,7 @@ func NewAuthenticator(db store.Database, key *rsa.PrivateKey, iss, aud string) *
 		a.iss = defaultPadlIssuer
 	}
 	if a.aud == "" {
-		a.aud = defaultPadlAudience
+		a.aud = PadlAPIAudience
 	}
 	return a
 }

--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/adrianosela/padl/lib/keys"
@@ -111,7 +112,7 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	if aud == PadlAPIAudience {
 		lifetime = time.Duration(time.Hour * 12)
 	} else if aud == PadlDeployKeyAudience {
-		lifetime = time.Duration(time.Hour * 12)
+		lifetime = time.Duration(math.MaxInt32)
 	} else {
 		return "", "", errors.New("Audience not regonized")
 	}

--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -114,7 +114,7 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	} else if aud == PadlDeployKeyAudience {
 		lifetime = time.Duration(math.MaxInt32)
 	} else {
-		return "", "", errors.New("Audience not regonized")
+		return "", "", errors.New("Audience not recognized")
 	}
 
 	cc := NewCustomClaims(email, aud, a.iss, lifetime)
@@ -124,7 +124,7 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	tk.Header["kid"] = keys.GetFingerprint(&a.signer.PublicKey)
 	signedTk, err := a.SignJWT(tk)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("could not sign JWT: %s", err)
 	}
 	return signedTk, id, nil
 }

--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
+	"log"
 	"time"
 
 	"github.com/adrianosela/padl/lib/keys"
@@ -112,8 +112,9 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	if aud == PadlAPIAudience {
 		lifetime = time.Duration(time.Hour * 12)
 	} else if aud == PadlDeployKeyAudience {
-		lifetime = time.Duration(math.MaxInt32)
+		lifetime = time.Duration(time.Hour * 12)
 	} else {
+		log.Println("Erroring here")
 		return "", "", errors.New("Audience not regonized")
 	}
 
@@ -124,6 +125,7 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	tk.Header["kid"] = keys.GetFingerprint(&a.signer.PublicKey)
 	signedTk, err := a.SignJWT(tk)
 	if err != nil {
+		log.Println("Erroring here2")
 		return "", "", err
 	}
 	return signedTk, id, nil

--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -4,11 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-<<<<<<< HEAD
 	"log"
-=======
-	"math"
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 	"time"
 
 	"github.com/adrianosela/padl/lib/keys"
@@ -116,14 +112,9 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	if aud == PadlAPIAudience {
 		lifetime = time.Duration(time.Hour * 12)
 	} else if aud == PadlDeployKeyAudience {
-<<<<<<< HEAD
 		lifetime = time.Duration(time.Hour * 12)
 	} else {
 		log.Println("Erroring here")
-=======
-		lifetime = time.Duration(math.MaxInt32)
-	} else {
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 		return "", "", errors.New("Audience not regonized")
 	}
 
@@ -134,10 +125,7 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	tk.Header["kid"] = keys.GetFingerprint(&a.signer.PublicKey)
 	signedTk, err := a.SignJWT(tk)
 	if err != nil {
-<<<<<<< HEAD
 		log.Println("Erroring here2")
-=======
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 		return "", "", err
 	}
 	return signedTk, id, nil

--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/adrianosela/padl/lib/keys"
@@ -114,7 +113,6 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	} else if aud == PadlDeployKeyAudience {
 		lifetime = time.Duration(time.Hour * 12)
 	} else {
-		log.Println("Erroring here")
 		return "", "", errors.New("Audience not regonized")
 	}
 
@@ -125,7 +123,6 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, e
 	tk.Header["kid"] = keys.GetFingerprint(&a.signer.PublicKey)
 	signedTk, err := a.SignJWT(tk)
 	if err != nil {
-		log.Println("Erroring here2")
 		return "", "", err
 	}
 	return signedTk, id, nil

--- a/api/auth/jwt.go
+++ b/api/auth/jwt.go
@@ -105,7 +105,7 @@ func (a *Authenticator) ValidateJWT(tkString string) (*CustomClaims, error) {
 }
 
 // GenerateJWT generates and signs a token for a given user
-func (a *Authenticator) GenerateJWT(email string, aud string) (string, error) {
+func (a *Authenticator) GenerateJWT(email string, aud string) (string, string, error) {
 
 	var lifetime time.Duration
 
@@ -114,15 +114,17 @@ func (a *Authenticator) GenerateJWT(email string, aud string) (string, error) {
 	} else if aud == PadlDeployKeyAudience {
 		lifetime = time.Duration(math.MaxInt32)
 	} else {
-		return "", errors.New("Audience not regonized")
+		return "", "", errors.New("Audience not regonized")
 	}
 
 	cc := NewCustomClaims(email, aud, a.iss, lifetime)
+
+	id := cc.Id
 	tk := newJWT(cc, jwt.SigningMethodRS512)
 	tk.Header["kid"] = keys.GetFingerprint(&a.signer.PublicKey)
 	signedTk, err := a.SignJWT(tk)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return signedTk, nil
+	return signedTk, id, nil
 }

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -55,6 +55,48 @@ func (p *Padl) CreateProject(name, description string, bits int) (*padlfile.File
 	return &pf, nil
 }
 
+//CreateDeployKey Creates a new DeployKey
+func (p *Padl) CreateDeployKey(projectName string, keyName string, description string) (*payloads.CreateDeployKeyResponse, error) {
+	pl := &payloads.CreateDeployKeyRequest{
+		DeployKeyName:        keyName,
+		DeployKeyDescription: description,
+	}
+	plBytes, err := json.Marshal(&pl)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshall payload: %s", err)
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/project/%s/deploy_key", p.HostURL, projectName),
+		bytes.NewBuffer(plBytes))
+	if err != nil {
+		return nil, fmt.Errorf("could not build http requests: %s", err)
+	}
+	p.setAuth(req)
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not send http request: %s", err)
+	}
+
+	respByt, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not read http response body: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
+	}
+
+	var createKeyResp payloads.CreateDeployKeyResponse
+
+	if err := json.Unmarshal(respByt, &createKeyResp); err != nil {
+		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
+	}
+
+	return &createKeyResp, nil
+}
+
 // GetProject gets a project by name if the requesting user has access to it
 func (p *Padl) GetProject(name string) (*project.Project, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/project/%s", p.HostURL, name), nil)

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -65,12 +65,8 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string, description s
 	if err != nil {
 		return nil, fmt.Errorf("could not marshall payload: %s", err)
 	}
-<<<<<<< HEAD
 	req, err := http.NewRequest(
 		http.MethodPost,
-=======
-	req, err := http.NewRequest(http.MethodPost,
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 		fmt.Sprintf("%s/project/%s/deploy_key", p.HostURL, projectName),
 		bytes.NewBuffer(plBytes))
 	if err != nil {
@@ -90,10 +86,7 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string, description s
 	}
 
 	if resp.StatusCode != http.StatusOK {
-<<<<<<< HEAD
 		fmt.Println(string(respByt))
-=======
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
 	}
 

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -65,7 +65,8 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string, description s
 	if err != nil {
 		return nil, fmt.Errorf("could not marshall payload: %s", err)
 	}
-	req, err := http.NewRequest(http.MethodPost,
+	req, err := http.NewRequest(
+		http.MethodPost,
 		fmt.Sprintf("%s/project/%s/deploy_key", p.HostURL, projectName),
 		bytes.NewBuffer(plBytes))
 	if err != nil {
@@ -85,6 +86,7 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string, description s
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		fmt.Println(string(respByt))
 		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
 	}
 

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -85,7 +85,6 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string) (*payloads.Cr
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		fmt.Println(string(respByt))
 		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
 	}
 
@@ -219,39 +218,39 @@ func (p *Padl) AddUserToProject(projectName string, email string, privilegeLvl i
 }
 
 // RemoveUserFromProject TODO
-func (p *Padl) RemoveUserFromProject(projectName string, email string) (string, error) {
+func (p *Padl) RemoveUserFromProject(projectName string, email string) error {
 	pl := &payloads.RemoveUserFromProjectRequest{
 		Email: email,
 	}
 	plBytes, err := json.Marshal(&pl)
 	if err != nil {
-		return "", fmt.Errorf("could not marshall payload: %s", err)
+		return fmt.Errorf("could not marshall payload: %s", err)
 	}
 	req, err := http.NewRequest(http.MethodDelete,
 		fmt.Sprintf("%s/project/%s/user", p.HostURL, projectName),
 		bytes.NewBuffer(plBytes))
 
 	if err != nil {
-		return "", fmt.Errorf("could not build http requests: %s", err)
+		return fmt.Errorf("could not build http requests: %s", err)
 	}
 
 	p.setAuth(req)
 
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("could not send http request: %s", err)
+		return fmt.Errorf("could not send http request: %s", err)
 	}
 
-	respByt, err := ioutil.ReadAll(resp.Body)
+	_, err = ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return "", fmt.Errorf("could not read http response body: %s", err)
+		return fmt.Errorf("could not read http response body: %s", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
+		return fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
 	}
-	return string(respByt), nil
+	return nil
 }
 
 // DeleteProject TODO

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -97,6 +97,47 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string, description s
 	return &createKeyResp, nil
 }
 
+//RemoveDeployKey Creates a new DeployKey
+func (p *Padl) RemoveDeployKey(projectName string, keyName string) (*payloads.CreateDeployKeyResponse, error) {
+	pl := &payloads.DeleteDeployKeyRequest{
+		DeployKeyName: keyName,
+	}
+	plBytes, err := json.Marshal(&pl)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshall payload: %s", err)
+	}
+	req, err := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("%s/project/%s/deploy_key", p.HostURL, projectName),
+		bytes.NewBuffer(plBytes))
+	if err != nil {
+		return nil, fmt.Errorf("could not build http requests: %s", err)
+	}
+	p.setAuth(req)
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not send http request: %s", err)
+	}
+
+	respByt, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not read http response body: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
+	}
+
+	var createKeyResp payloads.CreateDeployKeyResponse
+
+	if err := json.Unmarshal(respByt, &createKeyResp); err != nil {
+		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
+	}
+
+	return &createKeyResp, nil
+}
+
 // GetProject gets a project by name if the requesting user has access to it
 func (p *Padl) GetProject(name string) (*project.Project, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/project/%s", p.HostURL, name), nil)
@@ -200,9 +241,11 @@ func (p *Padl) RemoveUserFromProject(projectName string, email string) (string, 
 	req, err := http.NewRequest(http.MethodDelete,
 		fmt.Sprintf("%s/project/%s/user", p.HostURL, projectName),
 		bytes.NewBuffer(plBytes))
+
 	if err != nil {
 		return "", fmt.Errorf("could not build http requests: %s", err)
 	}
+
 	p.setAuth(req)
 
 	resp, err := p.HTTPClient.Do(req)

--- a/api/client/project.go
+++ b/api/client/project.go
@@ -56,10 +56,9 @@ func (p *Padl) CreateProject(name, description string, bits int) (*padlfile.File
 }
 
 //CreateDeployKey Creates a new DeployKey
-func (p *Padl) CreateDeployKey(projectName string, keyName string, description string) (*payloads.CreateDeployKeyResponse, error) {
+func (p *Padl) CreateDeployKey(projectName string, keyName string) (*payloads.CreateDeployKeyResponse, error) {
 	pl := &payloads.CreateDeployKeyRequest{
-		DeployKeyName:        keyName,
-		DeployKeyDescription: description,
+		DeployKeyName: keyName,
 	}
 	plBytes, err := json.Marshal(&pl)
 	if err != nil {
@@ -100,44 +99,32 @@ func (p *Padl) CreateDeployKey(projectName string, keyName string, description s
 }
 
 //RemoveDeployKey Creates a new DeployKey
-func (p *Padl) RemoveDeployKey(projectName string, keyName string) (*payloads.CreateDeployKeyResponse, error) {
+func (p *Padl) RemoveDeployKey(projectName string, keyName string) error {
 	pl := &payloads.DeleteDeployKeyRequest{
 		DeployKeyName: keyName,
 	}
 	plBytes, err := json.Marshal(&pl)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshall payload: %s", err)
+		return fmt.Errorf("could not marshall payload: %s", err)
 	}
 	req, err := http.NewRequest(http.MethodDelete,
 		fmt.Sprintf("%s/project/%s/deploy_key", p.HostURL, projectName),
 		bytes.NewBuffer(plBytes))
 	if err != nil {
-		return nil, fmt.Errorf("could not build http requests: %s", err)
+		return fmt.Errorf("could not build http requests: %s", err)
 	}
 	p.setAuth(req)
 
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("could not send http request: %s", err)
-	}
-
-	respByt, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	if err != nil {
-		return nil, fmt.Errorf("could not read http response body: %s", err)
+		return fmt.Errorf("could not send http request: %s", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
+		return fmt.Errorf("non 200 status code received: %d", resp.StatusCode)
 	}
 
-	var createKeyResp payloads.CreateDeployKeyResponse
-
-	if err := json.Unmarshal(respByt, &createKeyResp); err != nil {
-		return nil, fmt.Errorf("could not unmarshal http response body: %s", err)
-	}
-
-	return &createKeyResp, nil
+	return nil
 }
 
 // GetProject gets a project by name if the requesting user has access to it

--- a/api/payloads/project.go
+++ b/api/payloads/project.go
@@ -27,8 +27,7 @@ type RemoveUserFromProjectRequest struct {
 
 // CreateDeployKeyRequest TODO
 type CreateDeployKeyRequest struct {
-	DeployKeyName        string `json:"name"`
-	DeployKeyDescription string `json:"description"`
+	DeployKeyName string `json:"name"`
 }
 
 // DeleteDeployKeyRequest TODO
@@ -69,9 +68,6 @@ func (a *RemoveUserFromProjectRequest) Validate() error {
 func (r *CreateDeployKeyRequest) Validate() error {
 	if r.DeployKeyName == "" {
 		return errors.New("No name provided")
-	}
-	if r.DeployKeyDescription == "" {
-		return errors.New("No description provided")
 	}
 	return nil
 }

--- a/api/payloads/project.go
+++ b/api/payloads/project.go
@@ -38,7 +38,7 @@ type DeleteDeployKeyRequest struct {
 
 // CreateDeployKeyResponse TODO
 type CreateDeployKeyResponse struct {
-	DeployKey string `json:"deployKey"`
+	Token string `json:"token"`
 }
 
 // ListProjectsResponse TODO

--- a/api/payloads/project.go
+++ b/api/payloads/project.go
@@ -37,7 +37,7 @@ type DeleteDeployKeyRequest struct {
 
 // CreateDeployKeyResponse TODO
 type CreateDeployKeyResponse struct {
-	DeployKey string `json:"deployKey"`
+	Token string `json:"token"`
 }
 
 // ListProjectsResponse TODO

--- a/api/project/project.go
+++ b/api/project/project.go
@@ -66,11 +66,11 @@ func (p *Project) RemoveUser(email string) {
 }
 
 // SetDeployKey sets a deploy key on a project
-func (p *Project) SetDeployKey(name, value string) error {
+func (p *Project) SetDeployKey(name string, tokenID string) error {
 	if _, ok := p.DeployKeys[name]; ok {
 		return errors.New("a deploy key with this name exists")
 	}
-	p.DeployKeys[name] = value
+	p.DeployKeys[name] = tokenID
 	return nil
 }
 

--- a/api/service/auth.go
+++ b/api/service/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/adrianosela/padl/api/auth"
 	"github.com/adrianosela/padl/api/kms"
 	"github.com/adrianosela/padl/api/payloads"
 	"github.com/adrianosela/padl/api/user"
@@ -87,7 +88,7 @@ func (s *Service) loginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.authenticator.GenerateJWTForUser(user.Email)
+	token, err := s.authenticator.GenerateJWT(user.Email, auth.PadlAPIAudience)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error())) // fixme: if this happens we want to know

--- a/api/service/auth.go
+++ b/api/service/auth.go
@@ -88,7 +88,7 @@ func (s *Service) loginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.authenticator.GenerateJWT(user.Email, auth.PadlAPIAudience)
+	token, _, err := s.authenticator.GenerateJWT(user.Email, auth.PadlAPIAudience)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error())) // fixme: if this happens we want to know

--- a/api/service/middleware.go
+++ b/api/service/middleware.go
@@ -32,6 +32,7 @@ func (s *Service) Auth(h http.HandlerFunc) http.Handler {
 		}
 		// validate token
 		verifiedClaims, err := s.authenticator.ValidateJWT(tkStr)
+		
 		if err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
 			fmt.Fprint(w, "invalid access token")

--- a/api/service/project.go
+++ b/api/service/project.go
@@ -367,35 +367,26 @@ func (s *Service) createDeployKeyHandler(w http.ResponseWriter, r *http.Request)
 	if _, ok := p.Members[claims.Subject]; !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("User not in requested Project: %s", err)))
-<<<<<<< HEAD
 		log.Println("Erroring here5")
-=======
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 		return
 	}
 
 	if p.Members[claims.Subject] < privilege.PrivilegeLvlOwner {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("Only Owners can create deploy Keys")))
-<<<<<<< HEAD
 		log.Println("Erroring here6")
-=======
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 		return
 	}
 
 	keyEmail := dkeyPl.DeployKeyName + "." + p.Name + "@padl.adrianosela.com"
 
 	keyToken, keyID, err := s.authenticator.GenerateJWT(keyEmail, auth.PadlDeployKeyAudience)
-<<<<<<< HEAD
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not generate keyToken: %s", err)))
 		log.Println("Erroring here7")
 		return
 	}
-=======
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 
 	if err = p.SetDeployKey(dkeyPl.DeployKeyName, keyID); err != nil {
 		w.WriteHeader(http.StatusBadRequest)

--- a/api/service/project.go
+++ b/api/service/project.go
@@ -3,7 +3,6 @@ package service
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/adrianosela/padl/api/auth"
@@ -337,7 +336,6 @@ func (s *Service) createDeployKeyHandler(w http.ResponseWriter, r *http.Request)
 	if name = mux.Vars(r)["name"]; name == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("no project Name in request URL"))
-		log.Println("Erroring here1")
 		return
 	}
 	// get payload data
@@ -345,14 +343,12 @@ func (s *Service) createDeployKeyHandler(w http.ResponseWriter, r *http.Request)
 	if err := unmarshalRequestBody(r, &dkeyPl); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("could not unmarshall request body"))
-		log.Println("Erroring here2")
 		return
 	}
 	// validate payload data
 	if err := dkeyPl.Validate(); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not validate request: %s", err)))
-		log.Println("Erroring here3")
 		return
 	}
 	// fetch project from database
@@ -360,21 +356,18 @@ func (s *Service) createDeployKeyHandler(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not find project: %s", err)))
-		log.Println("Erroring here4")
 		return
 	}
 
 	if _, ok := p.Members[claims.Subject]; !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("User not in requested Project: %s", err)))
-		log.Println("Erroring here5")
 		return
 	}
 
 	if p.Members[claims.Subject] < privilege.PrivilegeLvlOwner {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("Only Owners can create deploy Keys")))
-		log.Println("Erroring here6")
 		return
 	}
 
@@ -384,21 +377,18 @@ func (s *Service) createDeployKeyHandler(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not generate keyToken: %s", err)))
-		log.Println("Erroring here7")
 		return
 	}
 
 	if err = p.SetDeployKey(dkeyPl.DeployKeyName, keyID); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not set new deploy key: %s", err)))
-		log.Println("Erroring here8")
 		return
 	}
 	// update project
 	if err := s.database.UpdateProject(p); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("could not update project: %s", err)))
-		log.Println("Erroring here9")
 		return
 	}
 	// marshall response
@@ -408,7 +398,6 @@ func (s *Service) createDeployKeyHandler(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(fmt.Sprintf("could not marshal project json: %s", err)))
-		log.Println("Erroring here0")
 		return
 	}
 	// send resp

--- a/cli/commands/flags.go
+++ b/cli/commands/flags.go
@@ -49,6 +49,10 @@ var (
 		Name:  "name",
 		Usage: "resource name",
 	}
+	keyNameFlag = cli.StringFlag{
+		Name:  "keyname",
+		Usage: "deploy key name",
+	}
 	descriptionFlag = cli.StringFlag{
 		Name:  "description",
 		Usage: "resource description",

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -395,6 +395,25 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 	return nil
 }
 
+func projectAddRemoveKeyHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	projectName := ctx.String(name(nameFlag))
+	keyName := ctx.String(name(keyNameFlag))
+
+	ok, err := c.RemoveDeployKey(projectName, keyName)
+	if err != nil {
+		return fmt.Errorf("error reomiving a deploy key: %s", err)
+	}
+
+	fmt.Println(ok)
+
+	return nil
+}
+
 func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
 	// TODO
 	return nil

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -292,7 +292,7 @@ func removeUserHandler(ctx *cli.Context) error {
 	projectName := ctx.String(name(nameFlag))
 	email := ctx.String(name(emailFlag))
 
-	_, err = c.RemoveUserFromProject(projectName, email)
+	err = c.RemoveUserFromProject(projectName, email)
 	if err != nil {
 		return fmt.Errorf("error removing user: %s", err)
 	}

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -92,6 +92,33 @@ var ProjectCmds = cli.Command{
 			},
 		},
 		{
+			Name:  "deploykey",
+			Usage: "manage secrets for project",
+			Subcommands: []cli.Command{
+				{
+					Name:  "add",
+					Usage: "add a deploy key to the project",
+					Flags: []cli.Flag{
+						asMandatory(nameFlag),
+						asMandatory(keyNameFlag),
+						descriptionFlag,
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectAddDeployKeyHandler,
+				},
+				{
+					Name:  "remove",
+					Usage: "remove a deploy key from the project",
+					Flags: []cli.Flag{
+						asMandatory(nameFlag),
+						asMandatory(keyNameFlag),
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectRemoveDeployKeyHandler,
+				},
+			},
+		},
+		{
 			Name:  "user",
 			Usage: "manage users for project",
 			Subcommands: []cli.Command{
@@ -249,6 +276,35 @@ func projectUpdateSecretHandler(ctx *cli.Context) error {
 }
 
 func projectRemoveSecretHandler(ctx *cli.Context) error {
+	// TODO
+	return nil
+}
+
+func projectAddDeployKeyHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	projectName := ctx.String(name(nameFlag))
+	keyName := ctx.String(name(keyNameFlag))
+	description := ctx.String(name(descriptionFlag))
+
+	resp, err := c.CreateDeployKey(projectName, keyName, description)
+	if err != nil {
+		return fmt.Errorf("error creating a deploy key: %s", err)
+	}
+
+	fmt.Println(resp.Token)
+
+	//TODO Generate a user "deploy" key
+
+	//TODO Generate a file to store token and key
+
+	return nil
+}
+
+func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
 	// TODO
 	return nil
 }

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -304,6 +304,25 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 	return nil
 }
 
+func projectAddRemoveKeyHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	projectName := ctx.String(name(nameFlag))
+	keyName := ctx.String(name(keyNameFlag))
+
+	ok, err := c.RemoveDeployKey(projectName, keyName)
+	if err != nil {
+		return fmt.Errorf("error reomiving a deploy key: %s", err)
+	}
+
+	fmt.Println(ok)
+
+	return nil
+}
+
 func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
 	// TODO
 	return nil

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -116,7 +116,6 @@ var ProjectCmds = cli.Command{
 						asMandatory(keyNameFlag),
 						descriptionFlag,
 					},
-					Before: checkCanModifyPadlFile,
 					Action: projectAddDeployKeyHandler,
 				},
 				{
@@ -126,7 +125,6 @@ var ProjectCmds = cli.Command{
 						asMandatory(nameFlag),
 						asMandatory(keyNameFlag),
 					},
-					Before: checkCanModifyPadlFile,
 					Action: projectRemoveDeployKeyHandler,
 				},
 			},
@@ -386,7 +384,7 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 		return fmt.Errorf("error creating a deploy key: %s", err)
 	}
 
-	fmt.Println(resp.Token)
+	fmt.Println(resp)
 
 	//TODO Generate a user "deploy" key
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -395,7 +395,7 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 	return nil
 }
 
-func projectAddRemoveKeyHandler(ctx *cli.Context) error {
+func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
 	c, err := getClient(ctx)
 	if err != nil {
 		return fmt.Errorf("could not initialize client: %s", err)
@@ -411,11 +411,6 @@ func projectAddRemoveKeyHandler(ctx *cli.Context) error {
 
 	fmt.Println(ok)
 
-	return nil
-}
-
-func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
-	// TODO
 	return nil
 }
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -114,7 +114,6 @@ var ProjectCmds = cli.Command{
 					Flags: []cli.Flag{
 						asMandatory(nameFlag),
 						asMandatory(keyNameFlag),
-						descriptionFlag,
 					},
 					Action: projectAddDeployKeyHandler,
 				},
@@ -377,9 +376,8 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 
 	projectName := ctx.String(name(nameFlag))
 	keyName := ctx.String(name(keyNameFlag))
-	description := ctx.String(name(descriptionFlag))
 
-	resp, err := c.CreateDeployKey(projectName, keyName, description)
+	resp, err := c.CreateDeployKey(projectName, keyName)
 	if err != nil {
 		return fmt.Errorf("error creating a deploy key: %s", err)
 	}
@@ -402,13 +400,10 @@ func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
 	projectName := ctx.String(name(nameFlag))
 	keyName := ctx.String(name(keyNameFlag))
 
-	ok, err := c.RemoveDeployKey(projectName, keyName)
+	err = c.RemoveDeployKey(projectName, keyName)
 	if err != nil {
 		return fmt.Errorf("error reomiving a deploy key: %s", err)
 	}
-
-	fmt.Println(ok)
-
 	return nil
 }
 
@@ -439,11 +434,10 @@ func removeUserHandler(ctx *cli.Context) error {
 	projectName := ctx.String(name(nameFlag))
 	email := ctx.String(name(emailFlag))
 
-	ok, err := c.RemoveUserFromProject(projectName, email)
+	_, err = c.RemoveUserFromProject(projectName, email)
 	if err != nil {
 		return fmt.Errorf("error removing user: %s", err)
 	}
-	fmt.Println(ok)
 	return nil
 }
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -116,10 +116,6 @@ var ProjectCmds = cli.Command{
 						asMandatory(keyNameFlag),
 						descriptionFlag,
 					},
-<<<<<<< HEAD
-=======
-					Before: checkCanModifyPadlFile,
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 					Action: projectAddDeployKeyHandler,
 				},
 				{
@@ -129,10 +125,6 @@ var ProjectCmds = cli.Command{
 						asMandatory(nameFlag),
 						asMandatory(keyNameFlag),
 					},
-<<<<<<< HEAD
-=======
-					Before: checkCanModifyPadlFile,
->>>>>>> 897d90ed7cb7a39c09ee4c82b2cd31b191147028
 					Action: projectRemoveDeployKeyHandler,
 				},
 			},
@@ -393,49 +385,6 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 	}
 
 	fmt.Println(resp)
-
-	//TODO Generate a user "deploy" key
-
-	//TODO Generate a file to store token and key
-
-	return nil
-}
-
-func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
-	c, err := getClient(ctx)
-	if err != nil {
-		return fmt.Errorf("could not initialize client: %s", err)
-	}
-
-	projectName := ctx.String(name(nameFlag))
-	keyName := ctx.String(name(keyNameFlag))
-
-	ok, err := c.RemoveDeployKey(projectName, keyName)
-	if err != nil {
-		return fmt.Errorf("error reomiving a deploy key: %s", err)
-	}
-
-	fmt.Println(ok)
-
-	return nil
-}
-
-func projectAddDeployKeyHandler(ctx *cli.Context) error {
-	c, err := getClient(ctx)
-	if err != nil {
-		return fmt.Errorf("could not initialize client: %s", err)
-	}
-
-	projectName := ctx.String(name(nameFlag))
-	keyName := ctx.String(name(keyNameFlag))
-	description := ctx.String(name(descriptionFlag))
-
-	resp, err := c.CreateDeployKey(projectName, keyName, description)
-	if err != nil {
-		return fmt.Errorf("error creating a deploy key: %s", err)
-	}
-
-	fmt.Println(resp.Token)
 
 	//TODO Generate a user "deploy" key
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -114,6 +114,7 @@ var ProjectCmds = cli.Command{
 					Flags: []cli.Flag{
 						asMandatory(nameFlag),
 						asMandatory(keyNameFlag),
+						jsonFlag,
 					},
 					Action: projectAddDeployKeyHandler,
 				},
@@ -382,7 +383,11 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 		return fmt.Errorf("error creating a deploy key: %s", err)
 	}
 
-	fmt.Println(resp)
+	if ctx.Bool(name(jsonFlag)) {
+		return printJSON(resp)
+	}
+
+	fmt.Println(resp.Token)
 
 	//TODO Generate a user "deploy" key
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -105,6 +105,33 @@ var ProjectCmds = cli.Command{
 			},
 		},
 		{
+			Name:  "deploykey",
+			Usage: "manage secrets for project",
+			Subcommands: []cli.Command{
+				{
+					Name:  "add",
+					Usage: "add a deploy key to the project",
+					Flags: []cli.Flag{
+						asMandatory(nameFlag),
+						asMandatory(keyNameFlag),
+						descriptionFlag,
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectAddDeployKeyHandler,
+				},
+				{
+					Name:  "remove",
+					Usage: "remove a deploy key from the project",
+					Flags: []cli.Flag{
+						asMandatory(nameFlag),
+						asMandatory(keyNameFlag),
+					},
+					Before: checkCanModifyPadlFile,
+					Action: projectRemoveDeployKeyHandler,
+				},
+			},
+		},
+		{
 			Name:  "user",
 			Usage: "manage users for project",
 			Subcommands: []cli.Command{
@@ -341,6 +368,35 @@ func projectRemoveSecretHandler(ctx *cli.Context) error {
 		return fmt.Errorf("could not write padlfile: %s", err)
 	}
 	fmt.Println("padlfile updated!")
+	return nil
+}
+
+func projectAddDeployKeyHandler(ctx *cli.Context) error {
+	c, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("could not initialize client: %s", err)
+	}
+
+	projectName := ctx.String(name(nameFlag))
+	keyName := ctx.String(name(keyNameFlag))
+	description := ctx.String(name(descriptionFlag))
+
+	resp, err := c.CreateDeployKey(projectName, keyName, description)
+	if err != nil {
+		return fmt.Errorf("error creating a deploy key: %s", err)
+	}
+
+	fmt.Println(resp.Token)
+
+	//TODO Generate a user "deploy" key
+
+	//TODO Generate a file to store token and key
+
+	return nil
+}
+
+func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
+	// TODO
 	return nil
 }
 

--- a/cli/commands/project.go
+++ b/cli/commands/project.go
@@ -304,7 +304,7 @@ func projectAddDeployKeyHandler(ctx *cli.Context) error {
 	return nil
 }
 
-func projectAddRemoveKeyHandler(ctx *cli.Context) error {
+func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
 	c, err := getClient(ctx)
 	if err != nil {
 		return fmt.Errorf("could not initialize client: %s", err)
@@ -320,11 +320,6 @@ func projectAddRemoveKeyHandler(ctx *cli.Context) error {
 
 	fmt.Println(ok)
 
-	return nil
-}
-
-func projectRemoveDeployKeyHandler(ctx *cli.Context) error {
-	// TODO
 	return nil
 }
 


### PR DESCRIPTION
Implemented add and remove for deploy keys

Create Deploy Key: returns a jwt token that never expires with a deploykey audience
padl project deploykey add --name {project_name} --keyname {deploy_key_name}

Remove Deploy Key: 
padl project deploykey remove --name {project_name} --keyname {deploy_key_name}

